### PR TITLE
Always put exception details into the HTML page

### DIFF
--- a/grails-app/views/error.gsp
+++ b/grails-app/views/error.gsp
@@ -8,13 +8,19 @@
 </head>
 
 <body>
-<g:if env="development">
-    <g:renderException exception="${exception}"/>
-</g:if>
-<g:else>
     <ul class="errors">
         <li>An error has occurred</li>
     </ul>
+    <div 
+<g:if env="development">
+  style="display:block;"
+</g:if>
+<g:else>
+  style="display:none;"
 </g:else>
+>
+    <g:renderException exception="${exception}"/>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
Add exception to HTML to help me debug the wide range of generic errors that spatial-test.ala.org.au is giving me.

Never coded in grails so not sure if this will actually work.