### PR TITLE
Purge logback to use with tomcat >= 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,15 @@ repositories {
     maven { url "https://repo.grails.org/grails/core" }
 }
 
+configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+        exclude group: 'ch.qos.logback', module: 'logback-classic'
+        exclude group: 'ch.qos.logback', module: 'logback-core'
+    }
+}
+
 dependencies {
-    compile "org.springframework.boot:spring-boot-starter-logging"
     compile "org.springframework.boot:spring-boot-autoconfigure"
     compile "org.springframework:spring-test:4.3.9.RELEASE"
     compile "org.grails:grails-core"


### PR DESCRIPTION
Fix for https://github.com/AtlasOfLivingAustralia/spatial-service/issues/140 that permits to run `spatial-service` in tomcat 8 and above.

Similar to:
https://github.com/AtlasOfLivingAustralia/sds-webapp2/issues/8