### PR TITLE
Liquibase integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
         classpath "org.grails.plugins:hibernate5:7.0.0"
         classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:2.0"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:3.0.10"
+        classpath 'org.grails.plugins:database-migration:3.1.0'
     }
 }
 
@@ -69,6 +70,14 @@ configurations {
     compile {
         //Avoid conflicting with 'org.hsqldb:hsqldb:2.4.1'
         exclude group: 'hsqldb', module: 'hsqldb'
+    }
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDir 'grails-app/migrations'
+        }
     }
 }
 
@@ -169,6 +178,11 @@ dependencies {
 
     compile 'org.springframework.boot:spring-boot-starter-data-redis:2.0.0.RELEASE'
     compile 'org.springframework.session:spring-session:1.3.5.RELEASE'
+
+    // db-migration
+    // In newer versions use 'implementation'
+    compile 'org.liquibase:liquibase-core:3.10.3'
+    compile "org.grails.plugins:database-migration:3.1.0"
 }
 
 configurations {

--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -1,0 +1,12 @@
+grails.plugin.databasemigration.changelogFileName = 'changelog.xml'
+grails.plugin.databasemigration.updateOnStart = true
+grails.plugin.databasemigration.updateOnStartFileName = 'changelog.xml'
+
+// We can limit the context where the db migration run
+// https://liquibase.org/blog/contexts-vs-labels
+// typically to skip during test or dev
+// grails.plugin.databasemigration.updateOnStartContexts = ['context1,context2']
+
+// If extra logs are needed for liquibase
+// logging.level.liquibase=on
+// logging.level.liquibase.executor=on

--- a/grails-app/migrations/changelog.xml
+++ b/grails-app/migrations/changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.6.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd">
+    <changeSet id="1" author="ALA Dev Team">
+        <modifyDataType columnName="bbox" newDataType="varchar(300)" tableName="objects"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Integration of liquibase following [this thread on slack](https://atlaslivingaustralia.slack.com/archives/CCTFGEU1G/p1652309366612159?thread_ts=1652284622.241829&cid=CCTFGEU1G) and continuing with the use of [liquibase for db migrations](https://github.com/AtlasOfLivingAustralia/collectory/pull/87).

This will allow to automatize the db migrations for the layers db in all spatial deployments. As a sample the modification of [objects.bbox](https://github.com/AtlasOfLivingAustralia/layers-store/commit/2b91e4794d0464f9736edd97392e29be67bcb6e0).

Before:

![image](https://user-images.githubusercontent.com/180085/168015336-472f97c9-b956-453f-8649-8bd31baee81e.png)

after this PR:

![image](https://user-images.githubusercontent.com/180085/168015274-7b048a22-ff13-4e61-85ac-b4dfc63867ab.png)

