### PR TITLE
Allow using a fixed locale as a workaround for issues with number formatting when adding layers

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -467,3 +467,5 @@ openapi:
   version: '@info.app.version@'
   cachetimeoutms: 4000
 
+# Allow setting a fixed locale to prevent number formatting issues: https://github.com/AtlasOfLivingAustralia/spatial-service/issues/247
+#useFixedLocale: en

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -19,7 +19,9 @@ beans = {
         noSSOStrategy(NoSSOStrategy) {}
     }
 
-    // Use fixed English locale, prevents issues with parsing of BBox decimal values in some locales
-    // https://github.com/AtlasOfLivingAustralia/spatial-service/issues/247
-    localeResolver(FixedLocaleResolver, new Locale('en'))
+    if (grailsApplication.config.useFixedLocale) {
+        // Use fixed English locale, prevents issues with parsing of BBox decimal values in some locales
+        // https://github.com/AtlasOfLivingAustralia/spatial-service/issues/247
+        localeResolver(FixedLocaleResolver, new Locale(grailsApplication.config.useFixedLocale))
+    }
 }

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -5,6 +5,7 @@ import au.org.ala.spatial.web.NoSSOStrategy
 import com.github.ziplet.filter.compression.CompressingFilter
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.core.Ordered
+import org.springframework.web.servlet.i18n.FixedLocaleResolver
 
 beans = {
     compressionFilter(FilterRegistrationBean) {
@@ -17,4 +18,8 @@ beans = {
     if (!application.config.security.cas.enabled && !application.config.security.oidc.enabled) {
         noSSOStrategy(NoSSOStrategy) {}
     }
+
+    // Use fixed English locale, prevents issues with parsing of BBox decimal values in some locales
+    // https://github.com/AtlasOfLivingAustralia/spatial-service/issues/247
+    localeResolver(FixedLocaleResolver, new Locale('en'))
 }


### PR DESCRIPTION
Using nl-be locale we encountered problems when adding layers.
Because of the difference in number formatting (thousands and decimal separators), the bounding box numbers would be out-of-whack when adding layers.

This is a simple workaround that should prevent these issues by allowing use to use a fixed locale, regardless of the user's choices made on the front-end.
Considering the spatial-service only serves admin pages and no real user-facing ones, this seems like a reasonable fix?