### PR TITLE
Fix grid layer upload and MaxEnt predictions

### DIFF
--- a/src/main/groovy/au/org/ala/spatial/process/LayerCreation.groovy
+++ b/src/main/groovy/au/org/ala/spatial/process/LayerCreation.groovy
@@ -92,7 +92,7 @@ class LayerCreation extends SlaveProcess {
             new File(outPath + "_tmp.bil").delete()
 
             taskWrapper.task.message = 'bil > diva'
-            Bil2diva.bil2diva(outPath, outPath, layer.environmentalvalueunits.toString())
+            Bil2diva.bil2diva(outPath, outPath, layer.environmentalvalueunits.toString(), spatialConfig.gdal.dir.toString(), 36000000)
 
             if ("Contextual".equalsIgnoreCase(layer.type.toString())) {
                 taskWrapper.task.message = "process grid file to shapes"

--- a/src/main/groovy/au/org/ala/spatial/util/OccurrenceData.groovy
+++ b/src/main/groovy/au/org/ala/spatial/util/OccurrenceData.groovy
@@ -35,7 +35,7 @@ class OccurrenceData {
 
         //remove sensitive records that will not be LSID matched
         try {
-            Records r = new Records(bs, q + "&fq=" + UriEncoder.encode("-sensitive:[* TO *]"), null, records_filename, null, facetName)
+            Records r = new Records(bs, q + "&fq=" + URLEncoder.encode("-sensitive:[* TO *]", "utf-8"), null, records_filename, null, facetName)
 
             StringBuilder sb = null
             if (r.getRecordsSize() > 0) {


### PR DESCRIPTION
We encountered some issues when trying to upload grid layers using the spatial-service admin interface.
And trying to run the MaxEnt prediction

First, an error was thrown, complaining the bil2diva method was not invoked correctly.
This made it the layers .grd file could not be created, preventing us to perform maxEnt modelling.
This seems like a small oversight of some past refactoring.

Second, the query fetching the occurences contained square brackets.
This is an issue we encountered in a bunch of other places as well and seems related to us using AWS loadbalancers isntead of nginx, which is more permissive.