### PR TITLE
#213

### DIFF
--- a/grails-app/services/au/org/ala/spatial/SandboxService.groovy
+++ b/grails-app/services/au/org/ala/spatial/SandboxService.groovy
@@ -570,7 +570,7 @@ class SandboxService {
         File processedDir = new File(spatialConfig.data.dir + "/sandbox/processed/" + datasetID);
         try {
             if (processedDir.exists()) {
-                FileUtils.deleteDirectory(processedDir);
+//                FileUtils.deleteDirectory(processedDir);
             }
         } catch (IOException e) {
             logger.error("Error deleting directory: " + processedDir.getAbsolutePath(), e);


### PR DESCRIPTION
- do not delete processed/<data-resource-id> directory so that we can obtain the pipeline jar log.